### PR TITLE
Remove Log Commit and Set Goal action buttons

### DIFF
--- a/GitStreak/ContentView.swift
+++ b/GitStreak/ContentView.swift
@@ -129,42 +129,6 @@ struct HomeView: View {
                     AchievementsView(achievements: dataModel.achievements)
                         .padding(.horizontal, 24)
                 }
-                
-                // Quick Actions
-                HStack(spacing: 16) {
-                    Button(action: {}) {
-                        VStack(spacing: 8) {
-                            Image(systemName: "plus")
-                                .font(.title2)
-                                .foregroundColor(.white)
-                            
-                            Text("Log Commit")
-                                .font(.caption)
-                                .foregroundColor(.white)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 64)
-                        .background(Color.blue)
-                        .cornerRadius(16)
-                    }
-                    
-                    Button(action: {}) {
-                        VStack(spacing: 8) {
-                            Image(systemName: "target")
-                                .font(.title2)
-                                .foregroundColor(.white)
-                            
-                            Text("Set Goal")
-                                .font(.caption)
-                                .foregroundColor(.white)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 64)
-                        .background(Color.green)
-                        .cornerRadius(16)
-                    }
-                }
-                .padding(.horizontal, 24)
                 .padding(.bottom, 24)
             }
         }


### PR DESCRIPTION
## Summary
• Removed the Quick Actions section containing Log Commit and Set Goal buttons from HomeView
• Simplified UI by focusing on core streak tracking and GitHub integration features
• Maintained proper spacing and layout structure after removal

## Test plan
- [ ] Build and run the app to verify buttons are removed
- [ ] Check that the HomeView layout still looks correct without the action buttons
- [ ] Verify all other functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)