### PR TITLE
Fix daily activity view alignment

### DIFF
--- a/GitStreak/Views/WeeklyActivityView.swift
+++ b/GitStreak/Views/WeeklyActivityView.swift
@@ -19,13 +19,19 @@ struct WeeklyActivityView: View {
                     .fontWeight(.medium)
             }
             
-            HStack(spacing: 8) {
+            HStack(alignment: .bottom, spacing: 8) {
                 ForEach(weeklyData) { day in
                     VStack(spacing: 8) {
-                        Rectangle()
-                            .fill(day.active ? Color.green : Color.gray.opacity(0.3))
-                            .frame(width: 32, height: max(CGFloat(day.commits) * 8, 16))
-                            .cornerRadius(4)
+                        ZStack(alignment: .bottom) {
+                            Rectangle()
+                                .fill(Color.clear)
+                                .frame(width: 32, height: 100)
+                            
+                            Rectangle()
+                                .fill(day.active ? Color.green : Color.gray.opacity(0.3))
+                                .frame(width: 32, height: max(CGFloat(day.commits) * 8, 16))
+                                .cornerRadius(4)
+                        }
                         
                         Text(day.day)
                             .font(.caption2)


### PR DESCRIPTION
## Summary
Fixed alignment issue in the daily activity view where day labels would move based on the height of activity bars.

## Changes
- Added fixed-height container (100px) with bottom alignment for activity bars
- Bars now grow upward from a consistent baseline while labels remain perfectly aligned
- Used `ZStack` with `alignment: .bottom` to ensure proper positioning

## Before/After
**Before:** Day labels moved up and down based on commit activity bar heights
**After:** Day labels remain consistently aligned horizontally regardless of bar height

## Visual Impact
- Cleaner, more professional appearance
- Improved readability and visual consistency
- Better user experience with predictable layout

## Test Plan
- [x] Tested with varying commit activity levels
- [x] Verified labels stay aligned across all days
- [x] Confirmed bars grow upward from baseline correctly
- [x] Validated on iOS Simulator

🤖 Generated with [Claude Code](https://claude.ai/code)