### PR TITLE
feat: Add View All functionality for Recent Activity section

### DIFF
--- a/GitStreak.xcodeproj/project.pbxproj
+++ b/GitStreak.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		1A2B3C4D5E6F7G8H9I0J1K2V /* WeeklyActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7G8H9I0J1K2W /* WeeklyActivityView.swift */; };
 		1A2B3C4D5E6F7G8H9I0J1K2X /* RecentActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7G8H9I0J1K2Y /* RecentActivityView.swift */; };
 		1A2B3C4D5E6F7G8H9I0J1K2Z /* AchievementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7G8H9I0J1K30 /* AchievementsView.swift */; };
+		1A2B3C4D5E6F7G8H9I0J1K3A /* AllCommitsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7G8H9I0J1K3B /* AllCommitsView.swift */; };
 		1A2B3C4D5E6F7G8H9I0J1K31 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7G8H9I0J1K32 /* TabBarView.swift */; };
 		1A2B3C4D5E6F7G8H9I0J1K33 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7G8H9I0J1K34 /* Assets.xcassets */; };
 		1A2B3C4D5E6F7G8H9I0J1K35 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7G8H9I0J1K36 /* Preview Assets.xcassets */; };
@@ -39,6 +40,7 @@
 		1A2B3C4D5E6F7G8H9I0J1K2W /* WeeklyActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyActivityView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7G8H9I0J1K2Y /* RecentActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentActivityView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7G8H9I0J1K30 /* AchievementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementsView.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7G8H9I0J1K3B /* AllCommitsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllCommitsView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7G8H9I0J1K32 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7G8H9I0J1K34 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7G8H9I0J1K36 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				1A2B3C4D5E6F7G8H9I0J1K2W /* WeeklyActivityView.swift */,
 				1A2B3C4D5E6F7G8H9I0J1K2Y /* RecentActivityView.swift */,
 				1A2B3C4D5E6F7G8H9I0J1K30 /* AchievementsView.swift */,
+				1A2B3C4D5E6F7G8H9I0J1K3B /* AllCommitsView.swift */,
 				1A2B3C4D5E6F7G8H9I0J1K32 /* TabBarView.swift */,
 			);
 			path = Views;
@@ -240,6 +243,7 @@
 				1A2B3C4D5E6F7G8H9I0J1K2V /* WeeklyActivityView.swift in Sources */,
 				1A2B3C4D5E6F7G8H9I0J1K2X /* RecentActivityView.swift in Sources */,
 				1A2B3C4D5E6F7G8H9I0J1K2Z /* AchievementsView.swift in Sources */,
+				1A2B3C4D5E6F7G8H9I0J1K3A /* AllCommitsView.swift in Sources */,
 				1A2B3C4D5E6F7G8H9I0J1K31 /* TabBarView.swift in Sources */,
 				1A2B3C4D5E6F7G8H9I0J1K2L /* GitStreakApp.swift in Sources */,
 			);

--- a/GitStreak.xcodeproj/project.pbxproj
+++ b/GitStreak.xcodeproj/project.pbxproj
@@ -15,10 +15,10 @@
 		1A2B3C4D5E6F7G8H9I0J1K2V /* WeeklyActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7G8H9I0J1K2W /* WeeklyActivityView.swift */; };
 		1A2B3C4D5E6F7G8H9I0J1K2X /* RecentActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7G8H9I0J1K2Y /* RecentActivityView.swift */; };
 		1A2B3C4D5E6F7G8H9I0J1K2Z /* AchievementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7G8H9I0J1K30 /* AchievementsView.swift */; };
-		1A2B3C4D5E6F7G8H9I0J1K3A /* AllCommitsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7G8H9I0J1K3B /* AllCommitsView.swift */; };
 		1A2B3C4D5E6F7G8H9I0J1K31 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7G8H9I0J1K32 /* TabBarView.swift */; };
 		1A2B3C4D5E6F7G8H9I0J1K33 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7G8H9I0J1K34 /* Assets.xcassets */; };
 		1A2B3C4D5E6F7G8H9I0J1K35 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7G8H9I0J1K36 /* Preview Assets.xcassets */; };
+		1A2B3C4D5E6F7G8H9I0J1K3A /* AllCommitsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7G8H9I0J1K3B /* AllCommitsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,11 +40,11 @@
 		1A2B3C4D5E6F7G8H9I0J1K2W /* WeeklyActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyActivityView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7G8H9I0J1K2Y /* RecentActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentActivityView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7G8H9I0J1K30 /* AchievementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementsView.swift; sourceTree = "<group>"; };
-		1A2B3C4D5E6F7G8H9I0J1K3B /* AllCommitsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllCommitsView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7G8H9I0J1K32 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7G8H9I0J1K34 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7G8H9I0J1K36 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		1A2B3C4D5E6F7G8H9I0J1K37 /* GitStreak.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GitStreak.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A2B3C4D5E6F7G8H9I0J1K3B /* AllCommitsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllCommitsView.swift; sourceTree = "<group>"; };
 		C99331832E3955BB00D19848 /* GitStreakTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GitStreakTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 

--- a/GitStreak/ContentView.swift
+++ b/GitStreak/ContentView.swift
@@ -29,6 +29,7 @@ struct ContentView: View {
 struct HomeView: View {
     @ObservedObject var dataModel: GitStreakDataModel
     @State private var showSettings = false
+    @State private var showAllCommits = false
     
     var body: some View {
         ScrollView {
@@ -100,7 +101,7 @@ struct HomeView: View {
                         Spacer()
                         
                         Button("View All") {
-                            // Handle view all
+                            showAllCommits = true
                         }
                         .font(.system(size: 13))
                         .foregroundColor(.blue)
@@ -125,6 +126,9 @@ struct HomeView: View {
         }
         .sheet(isPresented: $showSettings) {
             SettingsView(dataModel: dataModel)
+        }
+        .sheet(isPresented: $showAllCommits) {
+            AllCommitsView(dataModel: dataModel)
         }
     }
     

--- a/GitStreak/Models/GitStreakData.swift
+++ b/GitStreak/Models/GitStreakData.swift
@@ -695,4 +695,5 @@ class GitStreakDataModel: ObservableObject {
             loadMockData()
         }
     }
+    
 }

--- a/GitStreak/Models/GitStreakData.swift
+++ b/GitStreak/Models/GitStreakData.swift
@@ -229,8 +229,8 @@ class GitHubService: ObservableObject {
                     message: commit.commit.message,
                     time: formatRelativeTime(commit.commit.committer.date),
                     commits: 1,
-                    additions: Int.random(in: 10...200),  // Mock additions for now
-                    deletions: Int.random(in: 5...50)     // Mock deletions for now
+                    additions: nil,  // Real additions data requires fetching individual commit details
+                    deletions: nil   // Real deletions data requires fetching individual commit details
                 )
             }
             return nil

--- a/GitStreak/Models/GitStreakData.swift
+++ b/GitStreak/Models/GitStreakData.swift
@@ -623,6 +623,8 @@ class GitStreakDataModel: ObservableObject {
         // Generate mock monthly commits
         monthlyCommits = [
             CommitData(repo: "gitstreak", message: "Add .claude to .gitignore for improved file management", time: "3d ago", commits: 1, additions: 15, deletions: 2),
+            CommitData(repo: "large-refactor", message: "Major refactoring:\n- Updated all legacy components\n- Added new TypeScript definitions\n- Fixed multiple performance issues\n- Updated documentation", time: "1d ago", commits: 1, additions: 2500, deletions: 1200),
+            CommitData(repo: "data-migration", message: "Migrate database schema\n\nThis commit includes:\n\t- New table structures\n\t- Data migration scripts\n\t- Updated indexes", time: "2d ago", commits: 1, additions: 15000, deletions: 8500),
             CommitData(repo: "my-portfolio", message: "Update homepage design", time: "2h ago", commits: 3, additions: 124, deletions: 45),
             CommitData(repo: "react-components", message: "Add new button variants", time: "5h ago", commits: 2, additions: 89, deletions: 12),
             CommitData(repo: "api-server", message: "Fix authentication bug", time: "1d ago", commits: 1, additions: 34, deletions: 8),

--- a/GitStreak/Views/AllCommitsView.swift
+++ b/GitStreak/Views/AllCommitsView.swift
@@ -10,15 +10,10 @@ struct AllCommitsView: View {
     }
     
     var body: some View {
-        if #available(iOS 16.0, *) {
-            NavigationStack {
-                commitListView
-            }
-        } else {
-            NavigationView {
-                commitListView
-            }
+        NavigationView {
+            commitListView
         }
+        .navigationViewStyle(StackNavigationViewStyle()) // Ensures single column on all devices
     }
     
     private var commitListView: some View {

--- a/GitStreak/Views/AllCommitsView.swift
+++ b/GitStreak/Views/AllCommitsView.swift
@@ -21,55 +21,15 @@ struct AllCommitsView: View {
             Color(.systemGroupedBackground)
                 .ignoresSafeArea()
             
-            ScrollView {
-                    LazyVStack(spacing: 20, pinnedViews: []) {
-                        // Monthly Summary Card
-                        VStack(alignment: .leading, spacing: 12) {
-                            HStack {
-                                Image(systemName: "calendar")
-                                    .font(.title2)
-                                    .foregroundColor(.blue)
-                                
-                                Text("Last 30 Days")
-                                    .font(.title2)
-                                    .fontWeight(.bold)
-                                
-                                Spacer()
-                                
-                                Text(commitCountText)
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
-                            }
-                            .padding(.horizontal, 20)
-                            .padding(.top, 20)
-                            
-                            Divider()
-                                .padding(.horizontal, 20)
-                        }
-                        .background(Color(.systemBackground))
-                        .cornerRadius(16)
-                        .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
-                        .padding(.horizontal, 24)
-                        .padding(.top, 20)
-                        
-                        // Commits List - Using LazyVStack for better performance
-                        LazyVStack(spacing: 0) {
-                            ForEach(Array(dataModel.monthlyCommits.enumerated()), id: \.element.id) { index, commit in
-                                CommitRowView(commit: commit)
-                                
-                                if index < dataModel.monthlyCommits.count - 1 {
-                                    Divider()
-                                        .padding(.horizontal, 20)
-                                }
-                            }
-                        }
-                        .background(Color(.systemBackground))
-                        .cornerRadius(16)
-                        .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
-                        .padding(.horizontal, 24)
-                        .padding(.bottom, 24)
-                    }
-                }
+            if dataModel.isLoading {
+                loadingStateView
+            } else if let errorMessage = dataModel.errorMessage {
+                errorStateView(errorMessage)
+            } else if dataModel.monthlyCommits.isEmpty {
+                emptyStateView
+            } else {
+                commitsContentView
+            }
         }
         .navigationTitle("All Commits")
         .navigationBarTitleDisplayMode(.large)
@@ -79,6 +39,216 @@ struct AllCommitsView: View {
                     dismiss()
                 }
                 .fontWeight(.semibold)
+            }
+        }
+    }
+    
+    private var loadingStateView: some View {
+        VStack(spacing: 20) {
+            ProgressView()
+                .scaleEffect(1.2)
+                .progressViewStyle(CircularProgressViewStyle(tint: .blue))
+            
+            Text("Loading commits...")
+                .font(.headline)
+                .foregroundColor(.secondary)
+            
+            Text("Fetching your recent activity")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+    }
+    
+    private var emptyStateView: some View {
+        VStack(spacing: 24) {
+            ZStack {
+                Circle()
+                    .fill(
+                        LinearGradient(
+                            colors: [Color.blue.opacity(0.2), Color.purple.opacity(0.1)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: 120, height: 120)
+                
+                Image(systemName: "calendar.badge.exclamationmark")
+                    .font(.system(size: 60))
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [Color.blue, Color.purple],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+            }
+            
+            VStack(spacing: 12) {
+                Text("No Commits Found")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                    .foregroundColor(.primary)
+                
+                Text("You haven't made any commits in the last 30 days.\nStart coding to see your activity here!")
+                    .font(.body)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(nil)
+            }
+            
+            Button(action: {
+                dataModel.refreshData()
+            }) {
+                HStack {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 16, weight: .semibold))
+                    
+                    Text("Refresh")
+                        .fontWeight(.semibold)
+                }
+                .frame(minWidth: 120)
+                .padding(.vertical, 12)
+                .padding(.horizontal, 24)
+                .background(
+                    LinearGradient(
+                        colors: [Color.blue, Color.blue.opacity(0.8)],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
+                .foregroundColor(.white)
+                .cornerRadius(25)
+                .shadow(color: Color.blue.opacity(0.3), radius: 8, x: 0, y: 4)
+            }
+        }
+        .padding(.horizontal, 40)
+    }
+    
+    private func errorStateView(_ errorMessage: String) -> some View {
+        VStack(spacing: 24) {
+            ZStack {
+                Circle()
+                    .fill(
+                        LinearGradient(
+                            colors: [Color.red.opacity(0.2), Color.orange.opacity(0.1)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: 120, height: 120)
+                
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 60))
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [Color.red, Color.orange],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+            }
+            
+            VStack(spacing: 12) {
+                Text("Failed to Load Commits")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                    .foregroundColor(.primary)
+                
+                Text(errorMessage)
+                    .font(.body)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(nil)
+            }
+            
+            VStack(spacing: 12) {
+                Button(action: {
+                    dataModel.refreshData()
+                }) {
+                    HStack {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 16, weight: .semibold))
+                        
+                        Text("Try Again")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(minWidth: 120)
+                    .padding(.vertical, 12)
+                    .padding(.horizontal, 24)
+                    .background(
+                        LinearGradient(
+                            colors: [Color.blue, Color.blue.opacity(0.8)],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .foregroundColor(.white)
+                    .cornerRadius(25)
+                    .shadow(color: Color.blue.opacity(0.3), radius: 8, x: 0, y: 4)
+                }
+                
+                Button(action: {
+                    dismiss()
+                }) {
+                    Text("Go Back")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding(.horizontal, 40)
+    }
+    
+    private var commitsContentView: some View {
+        ScrollView {
+            LazyVStack(spacing: 20, pinnedViews: []) {
+                // Monthly Summary Card
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack {
+                        Image(systemName: "calendar")
+                            .font(.title2)
+                            .foregroundColor(.blue)
+                        
+                        Text("Last 30 Days")
+                            .font(.title2)
+                            .fontWeight(.bold)
+                        
+                        Spacer()
+                        
+                        Text(commitCountText)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.top, 20)
+                    
+                    Divider()
+                        .padding(.horizontal, 20)
+                }
+                .background(Color(.systemBackground))
+                .cornerRadius(16)
+                .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
+                .padding(.horizontal, 24)
+                .padding(.top, 20)
+                
+                // Commits List - Using LazyVStack for better performance
+                LazyVStack(spacing: 0) {
+                    ForEach(Array(dataModel.monthlyCommits.enumerated()), id: \.element.id) { index, commit in
+                        CommitRowView(commit: commit)
+                        
+                        if index < dataModel.monthlyCommits.count - 1 {
+                            Divider()
+                                .padding(.horizontal, 20)
+                        }
+                    }
+                }
+                .background(Color(.systemBackground))
+                .cornerRadius(16)
+                .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
+                .padding(.horizontal, 24)
+                .padding(.bottom, 24)
             }
         }
     }

--- a/GitStreak/Views/AllCommitsView.swift
+++ b/GitStreak/Views/AllCommitsView.swift
@@ -4,12 +4,12 @@ struct AllCommitsView: View {
     @ObservedObject var dataModel: GitStreakDataModel
     @Environment(\.dismiss) private var dismiss
     
-    private var commitCountText: String {
+    internal var commitCountText: String {
         let count = dataModel.monthlyCommits.count
         return "\(count) \(count == 1 ? "commit" : "commits")"
     }
     
-    private func formatLargeNumber(_ number: Int) -> String {
+    internal func formatLargeNumber(_ number: Int) -> String {
         if number >= 1000000 {
             return String(format: "%.1fM", Double(number) / 1000000.0)
         } else if number >= 1000 {
@@ -18,15 +18,21 @@ struct AllCommitsView: View {
         return "\(number)"
     }
     
-    private func sanitizeCommitMessage(_ message: String) -> String {
-        return message
+    internal func sanitizeCommitMessage(_ message: String) -> String {
+        let sanitized = message
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .replacingOccurrences(of: "\n", with: " ")
             .replacingOccurrences(of: "\r", with: " ")
             .replacingOccurrences(of: "\t", with: " ")
-            .replacingOccurrences(of: "  ", with: " ") // Replace double spaces
-            .prefix(200)
-            .description
+        
+        // Replace multiple consecutive spaces with a single space using regex
+        let singleSpaced = sanitized.replacingOccurrences(
+            of: " +", 
+            with: " ", 
+            options: .regularExpression
+        )
+        
+        return String(singleSpaced.prefix(200))
     }
     
     var body: some View {

--- a/GitStreak/Views/AllCommitsView.swift
+++ b/GitStreak/Views/AllCommitsView.swift
@@ -11,7 +11,7 @@ struct AllCommitsView: View {
                     .ignoresSafeArea()
                 
                 ScrollView {
-                    VStack(spacing: 20) {
+                    LazyVStack(spacing: 20, pinnedViews: []) {
                         // Monthly Summary Card
                         VStack(alignment: .leading, spacing: 12) {
                             HStack {
@@ -41,12 +41,12 @@ struct AllCommitsView: View {
                         .padding(.horizontal, 24)
                         .padding(.top, 20)
                         
-                        // Commits List
-                        VStack(spacing: 0) {
-                            ForEach(dataModel.monthlyCommits) { commit in
+                        // Commits List - Using LazyVStack for better performance
+                        LazyVStack(spacing: 0) {
+                            ForEach(Array(dataModel.monthlyCommits.enumerated()), id: \.element.id) { index, commit in
                                 CommitRowView(commit: commit)
                                 
-                                if commit.id != dataModel.monthlyCommits.last?.id {
+                                if index < dataModel.monthlyCommits.count - 1 {
                                     Divider()
                                         .padding(.horizontal, 20)
                                 }
@@ -77,16 +77,19 @@ struct AllCommitsView: View {
 struct CommitRowView: View {
     let commit: CommitData
     
+    // Pre-define gradient for better performance
+    private let iconGradient = LinearGradient(
+        colors: [Color.green.opacity(0.3), Color.green.opacity(0.1)],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+    
     var body: some View {
         HStack(spacing: 16) {
             // Commit icon with gradient background
             ZStack {
                 Circle()
-                    .fill(LinearGradient(
-                        colors: [Color.green.opacity(0.3), Color.green.opacity(0.1)],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    ))
+                    .fill(iconGradient)
                     .frame(width: 44, height: 44)
                 
                 Image(systemName: "chevron.left.forwardslash.chevron.right")

--- a/GitStreak/Views/AllCommitsView.swift
+++ b/GitStreak/Views/AllCommitsView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+struct AllCommitsView: View {
+    @ObservedObject var dataModel: GitStreakDataModel
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color(.systemGroupedBackground)
+                    .ignoresSafeArea()
+                
+                ScrollView {
+                    VStack(spacing: 20) {
+                        // Monthly Summary Card
+                        VStack(alignment: .leading, spacing: 12) {
+                            HStack {
+                                Image(systemName: "calendar")
+                                    .font(.title2)
+                                    .foregroundColor(.blue)
+                                
+                                Text("Last 30 Days")
+                                    .font(.title2)
+                                    .fontWeight(.bold)
+                                
+                                Spacer()
+                                
+                                Text("\(dataModel.monthlyCommits.count) commits")
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            }
+                            .padding(.horizontal, 20)
+                            .padding(.top, 20)
+                            
+                            Divider()
+                                .padding(.horizontal, 20)
+                        }
+                        .background(Color(.systemBackground))
+                        .cornerRadius(16)
+                        .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
+                        .padding(.horizontal, 24)
+                        .padding(.top, 20)
+                        
+                        // Commits List
+                        VStack(spacing: 0) {
+                            ForEach(dataModel.monthlyCommits) { commit in
+                                CommitRowView(commit: commit)
+                                
+                                if commit.id != dataModel.monthlyCommits.last?.id {
+                                    Divider()
+                                        .padding(.horizontal, 20)
+                                }
+                            }
+                        }
+                        .background(Color(.systemBackground))
+                        .cornerRadius(16)
+                        .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
+                        .padding(.horizontal, 24)
+                        .padding(.bottom, 24)
+                    }
+                }
+            }
+            .navigationTitle("All Commits")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                    .fontWeight(.semibold)
+                }
+            }
+        }
+    }
+}
+
+struct CommitRowView: View {
+    let commit: CommitData
+    
+    var body: some View {
+        HStack(spacing: 16) {
+            // Commit icon with gradient background
+            ZStack {
+                Circle()
+                    .fill(LinearGradient(
+                        colors: [Color.green.opacity(0.3), Color.green.opacity(0.1)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ))
+                    .frame(width: 44, height: 44)
+                
+                Image(systemName: "chevron.left.forwardslash.chevron.right")
+                    .font(.system(size: 18))
+                    .foregroundColor(.green)
+            }
+            
+            VStack(alignment: .leading, spacing: 4) {
+                Text(commit.repo)
+                    .font(.headline)
+                    .foregroundColor(.primary)
+                
+                Text(commit.message)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+                
+                HStack(spacing: 12) {
+                    if let additions = commit.additions {
+                        Label("\(additions)", systemImage: "plus.circle.fill")
+                            .font(.caption)
+                            .foregroundColor(.green)
+                    }
+                    
+                    if let deletions = commit.deletions {
+                        Label("\(deletions)", systemImage: "minus.circle.fill")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                    
+                    Spacer()
+                    
+                    Text(commit.time)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            
+            Spacer()
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+    }
+}
+
+#Preview {
+    AllCommitsView(dataModel: GitStreakDataModel())
+}

--- a/GitStreak/Views/AllCommitsView.swift
+++ b/GitStreak/Views/AllCommitsView.swift
@@ -4,6 +4,11 @@ struct AllCommitsView: View {
     @ObservedObject var dataModel: GitStreakDataModel
     @Environment(\.dismiss) private var dismiss
     
+    private var commitCountText: String {
+        let count = dataModel.monthlyCommits.count
+        return "\(count) \(count == 1 ? "commit" : "commits")"
+    }
+    
     var body: some View {
         NavigationView {
             ZStack {
@@ -25,7 +30,7 @@ struct AllCommitsView: View {
                                 
                                 Spacer()
                                 
-                                Text("\(dataModel.monthlyCommits.count) commits")
+                                Text(commitCountText)
                                     .font(.subheadline)
                                     .foregroundColor(.secondary)
                             }

--- a/GitStreak/Views/AllCommitsView.swift
+++ b/GitStreak/Views/AllCommitsView.swift
@@ -10,12 +10,23 @@ struct AllCommitsView: View {
     }
     
     var body: some View {
-        NavigationView {
-            ZStack {
-                Color(.systemGroupedBackground)
-                    .ignoresSafeArea()
-                
-                ScrollView {
+        if #available(iOS 16.0, *) {
+            NavigationStack {
+                commitListView
+            }
+        } else {
+            NavigationView {
+                commitListView
+            }
+        }
+    }
+    
+    private var commitListView: some View {
+        ZStack {
+            Color(.systemGroupedBackground)
+                .ignoresSafeArea()
+            
+            ScrollView {
                     LazyVStack(spacing: 20, pinnedViews: []) {
                         // Monthly Summary Card
                         VStack(alignment: .leading, spacing: 12) {
@@ -64,16 +75,15 @@ struct AllCommitsView: View {
                         .padding(.bottom, 24)
                     }
                 }
-            }
-            .navigationTitle("All Commits")
-            .navigationBarTitleDisplayMode(.large)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Done") {
-                        dismiss()
-                    }
-                    .fontWeight(.semibold)
+        }
+        .navigationTitle("All Commits")
+        .navigationBarTitleDisplayMode(.large)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Done") {
+                    dismiss()
                 }
+                .fontWeight(.semibold)
             }
         }
     }

--- a/GitStreakTests/AllCommitsViewIntegrationTests.swift
+++ b/GitStreakTests/AllCommitsViewIntegrationTests.swift
@@ -1,0 +1,289 @@
+import XCTest
+import SwiftUI
+@testable import GitStreak
+
+class AllCommitsViewIntegrationTests: XCTestCase {
+    
+    var dataModel: GitStreakDataModel!
+    
+    override func setUp() {
+        super.setUp()
+        dataModel = GitStreakDataModel()
+    }
+    
+    override func tearDown() {
+        dataModel = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Navigation Integration Tests
+    
+    func testAllCommitsViewNavigationFlow() {
+        // Test the full flow from ContentView to AllCommitsView
+        let contentView = ContentView()
+        XCTAssertNotNil(contentView, "ContentView should be instantiable for navigation testing")
+        
+        // Test HomeView with data model
+        let homeView = HomeView(dataModel: dataModel)
+        XCTAssertNotNil(homeView, "HomeView should be accessible for navigation")
+        
+        // Test AllCommitsView instantiation from navigation
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        XCTAssertNotNil(allCommitsView, "AllCommitsView should be accessible via navigation")
+    }
+    
+    func testAllCommitsViewModalPresentation() {
+        // Test that AllCommitsView works as a modal presentation
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        // Verify view can be created and has necessary components for modal presentation
+        XCTAssertNotNil(allCommitsView, "Modal AllCommitsView should be instantiable")
+        
+        let body = allCommitsView.body
+        XCTAssertNotNil(body, "Modal presentation should have a body")
+    }
+    
+    // MARK: - State Transition Integration Tests
+    
+    func testStateTransitionsInRealTime() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        // Test loading state
+        dataModel.isLoading = true
+        dataModel.errorMessage = nil
+        dataModel.monthlyCommits = []
+        
+        XCTAssertNotNil(allCommitsView, "View should handle loading state transition")
+        
+        // Test error state transition
+        dataModel.isLoading = false
+        dataModel.errorMessage = "Network error occurred"
+        
+        XCTAssertNotNil(allCommitsView, "View should handle loading to error state transition")
+        
+        // Test empty state transition
+        dataModel.errorMessage = nil
+        dataModel.monthlyCommits = []
+        
+        XCTAssertNotNil(allCommitsView, "View should handle error to empty state transition")
+        
+        // Test content state transition
+        dataModel.monthlyCommits = [
+            CommitData(repo: "test", message: "Test commit", time: "1h ago", commits: 1)
+        ]
+        
+        XCTAssertNotNil(allCommitsView, "View should handle empty to content state transition")
+    }
+    
+    func testDataRefreshIntegration() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        // Test initial state
+        XCTAssertNotNil(allCommitsView, "Initial view should be created")
+        
+        // Simulate data refresh (this would trigger in UI through refresh buttons)
+        let initialCommitCount = dataModel.monthlyCommits.count
+        
+        // Add new commits to simulate refresh
+        dataModel.monthlyCommits.append(
+            CommitData(repo: "new-repo", message: "New commit after refresh", time: "now", commits: 1)
+        )
+        
+        XCTAssertEqual(dataModel.monthlyCommits.count, initialCommitCount + 1, 
+                      "Data model should reflect refreshed data")
+        
+        // View should still be valid after data changes
+        XCTAssertNotNil(allCommitsView, "View should remain valid after data refresh")
+    }
+    
+    // MARK: - Performance Integration Tests
+    
+    func testLargeDataSetRendering() {
+        // Create large dataset to test rendering performance
+        var largeDataSet: [CommitData] = []
+        for i in 0..<500 {
+            largeDataSet.append(CommitData(
+                repo: "repo-\(i % 50)", // Vary repo names
+                message: "Commit \(i): " + String(repeating: "Lorem ipsum ", count: (i % 10) + 1),
+                time: "\(i % 24)h ago",
+                commits: 1,
+                additions: Int.random(in: 0...10000),
+                deletions: Int.random(in: 0...5000)
+            ))
+        }
+        
+        dataModel.isLoading = false
+        dataModel.errorMessage = nil
+        dataModel.monthlyCommits = largeDataSet
+        
+        measure {
+            let allCommitsView = AllCommitsView(dataModel: dataModel)
+            _ = allCommitsView.body // Force body evaluation
+        }
+    }
+    
+    func testRapidStateChanges() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        measure {
+            // Simulate rapid state changes that might occur in real usage
+            for i in 0..<100 {
+                if i % 4 == 0 {
+                    dataModel.isLoading = true
+                    dataModel.errorMessage = nil
+                    dataModel.monthlyCommits = []
+                } else if i % 4 == 1 {
+                    dataModel.isLoading = false
+                    dataModel.errorMessage = "Error \(i)"
+                    dataModel.monthlyCommits = []
+                } else if i % 4 == 2 {
+                    dataModel.isLoading = false
+                    dataModel.errorMessage = nil
+                    dataModel.monthlyCommits = []
+                } else {
+                    dataModel.isLoading = false
+                    dataModel.errorMessage = nil
+                    dataModel.monthlyCommits = [
+                        CommitData(repo: "test-\(i)", message: "Message \(i)", time: "1h ago", commits: 1)
+                    ]
+                }
+                
+                // Access the body to ensure view can handle the state change
+                _ = allCommitsView.body
+            }
+        }
+    }
+    
+    // MARK: - Data Consistency Integration Tests
+    
+    func testDataModelConsistency() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        // Ensure data model maintains consistency across different operations
+        let initialData = dataModel.monthlyCommits
+        
+        // Test commit count consistency
+        let initialCountText = allCommitsView.commitCountText
+        let expectedInitialCount = "\(initialData.count) \(initialData.count == 1 ? "commit" : "commits")"
+        XCTAssertEqual(initialCountText, expectedInitialCount, "Initial count should be consistent")
+        
+        // Add commits and verify consistency
+        dataModel.monthlyCommits.append(contentsOf: [
+            CommitData(repo: "test1", message: "Test 1", time: "1h ago", commits: 1),
+            CommitData(repo: "test2", message: "Test 2", time: "2h ago", commits: 1)
+        ])
+        
+        let updatedCountText = allCommitsView.commitCountText
+        let expectedUpdatedCount = "\(dataModel.monthlyCommits.count) commits"
+        XCTAssertEqual(updatedCountText, expectedUpdatedCount, "Updated count should be consistent")
+        
+        // Clear commits and verify
+        dataModel.monthlyCommits = []
+        let emptyCountText = allCommitsView.commitCountText
+        XCTAssertEqual(emptyCountText, "0 commits", "Empty count should be consistent")
+    }
+    
+    func testFormattingConsistencyAcrossStates() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        // Create commits with various number formats to test consistency
+        let testCommits = [
+            CommitData(repo: "small", message: "Small changes", time: "1h ago", commits: 1, 
+                      additions: 50, deletions: 25),
+            CommitData(repo: "medium", message: "Medium changes", time: "2h ago", commits: 1, 
+                      additions: 1500, deletions: 750),
+            CommitData(repo: "large", message: "Large changes", time: "3h ago", commits: 1, 
+                      additions: 15000, deletions: 7500),
+            CommitData(repo: "huge", message: "Huge changes", time: "4h ago", commits: 1, 
+                      additions: 1500000, deletions: 750000),
+        ]
+        
+        dataModel.monthlyCommits = testCommits
+        dataModel.isLoading = false
+        dataModel.errorMessage = nil
+        
+        // Verify formatting is consistent
+        XCTAssertEqual(allCommitsView.formatLargeNumber(50), "50")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(1500), "1.5K")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(15000), "15.0K")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(1500000), "1.5M")
+        
+        // Verify view can render with all these different formats
+        XCTAssertNotNil(allCommitsView.body, "View should render consistently with mixed number formats")
+    }
+    
+    func testMessageSanitizationConsistency() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        let messyCommits = [
+            CommitData(repo: "test1", message: "Clean message", time: "1h ago", commits: 1),
+            CommitData(repo: "test2", message: "  Message with spaces  ", time: "2h ago", commits: 1),
+            CommitData(repo: "test3", message: "Message\nwith\nnewlines", time: "3h ago", commits: 1),
+            CommitData(repo: "test4", message: "Message\twith\ttabs", time: "4h ago", commits: 1),
+            CommitData(repo: "test5", message: String(repeating: "Very long message ", count: 20), time: "5h ago", commits: 1),
+        ]
+        
+        dataModel.monthlyCommits = messyCommits
+        dataModel.isLoading = false
+        dataModel.errorMessage = nil
+        
+        // Verify sanitization works consistently
+        for commit in messyCommits {
+            let sanitized = allCommitsView.sanitizeCommitMessage(commit.message)
+            
+            // Should not contain newlines, tabs, or excessive whitespace
+            XCTAssertFalse(sanitized.contains("\n"), "Sanitized message should not contain newlines")
+            XCTAssertFalse(sanitized.contains("\t"), "Sanitized message should not contain tabs")
+            XCTAssertFalse(sanitized.contains("  "), "Sanitized message should not contain double spaces")
+            XCTAssertTrue(sanitized.count <= 200, "Sanitized message should be truncated to 200 characters")
+            XCTAssertEqual(sanitized, sanitized.trimmingCharacters(in: .whitespacesAndNewlines),
+                          "Sanitized message should have no leading/trailing whitespace")
+        }
+        
+        // View should render consistently with all sanitized messages
+        XCTAssertNotNil(allCommitsView.body, "View should render consistently with sanitized messages")
+    }
+    
+    // MARK: - Error Handling Integration Tests
+    
+    func testErrorStateRecovery() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        // Start in error state
+        dataModel.isLoading = false
+        dataModel.errorMessage = "Network timeout"
+        dataModel.monthlyCommits = []
+        
+        XCTAssertNotNil(allCommitsView.body, "Should render error state")
+        
+        // Simulate recovery with data
+        dataModel.errorMessage = nil
+        dataModel.monthlyCommits = [
+            CommitData(repo: "recovered", message: "Data recovered", time: "now", commits: 1)
+        ]
+        
+        XCTAssertNotNil(allCommitsView.body, "Should render recovered state")
+        XCTAssertEqual(allCommitsView.commitCountText, "1 commit", "Should show correct count after recovery")
+    }
+    
+    func testEmptyStateRecovery() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        // Start in empty state
+        dataModel.isLoading = false
+        dataModel.errorMessage = nil
+        dataModel.monthlyCommits = []
+        
+        XCTAssertNotNil(allCommitsView.body, "Should render empty state")
+        XCTAssertEqual(allCommitsView.commitCountText, "0 commits", "Should show zero commits")
+        
+        // Simulate data arrival
+        dataModel.monthlyCommits = [
+            CommitData(repo: "new-data", message: "New data arrived", time: "now", commits: 1),
+            CommitData(repo: "more-data", message: "More data arrived", time: "1m ago", commits: 1)
+        ]
+        
+        XCTAssertNotNil(allCommitsView.body, "Should render content state after recovery")
+        XCTAssertEqual(allCommitsView.commitCountText, "2 commits", "Should show correct count after recovery")
+    }
+}

--- a/GitStreakTests/AllCommitsViewTests.swift
+++ b/GitStreakTests/AllCommitsViewTests.swift
@@ -1,0 +1,371 @@
+import XCTest
+import SwiftUI
+@testable import GitStreak
+
+class AllCommitsViewTests: XCTestCase {
+    
+    var dataModel: GitStreakDataModel!
+    
+    override func setUp() {
+        super.setUp()
+        dataModel = GitStreakDataModel()
+    }
+    
+    override func tearDown() {
+        dataModel = nil
+        super.tearDown()
+    }
+    
+    // MARK: - AllCommitsView Basic Tests
+    
+    func testAllCommitsViewInstantiation() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        XCTAssertNotNil(allCommitsView, "AllCommitsView should be instantiable")
+        
+        let body = allCommitsView.body
+        XCTAssertNotNil(body, "AllCommitsView should have a body")
+    }
+    
+    func testCommitCountTextSingular() {
+        // Create data model with single commit
+        dataModel.monthlyCommits = [
+            CommitData(repo: "test-repo", message: "Single commit", time: "1h ago", commits: 1)
+        ]
+        
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        let countText = allCommitsView.commitCountText
+        
+        XCTAssertEqual(countText, "1 commit", "Should show singular 'commit' for single commit")
+    }
+    
+    func testCommitCountTextPlural() {
+        // Create data model with multiple commits
+        dataModel.monthlyCommits = [
+            CommitData(repo: "test-repo1", message: "First commit", time: "1h ago", commits: 1),
+            CommitData(repo: "test-repo2", message: "Second commit", time: "2h ago", commits: 1),
+            CommitData(repo: "test-repo3", message: "Third commit", time: "3h ago", commits: 1)
+        ]
+        
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        let countText = allCommitsView.commitCountText
+        
+        XCTAssertEqual(countText, "3 commits", "Should show plural 'commits' for multiple commits")
+    }
+    
+    func testCommitCountTextZero() {
+        // Create data model with no commits
+        dataModel.monthlyCommits = []
+        
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        let countText = allCommitsView.commitCountText
+        
+        XCTAssertEqual(countText, "0 commits", "Should show '0 commits' for empty array")
+    }
+    
+    // MARK: - Data Formatting Function Tests
+    
+    func testFormatLargeNumberSmall() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        XCTAssertEqual(allCommitsView.formatLargeNumber(5), "5")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(99), "99")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(567), "567")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(999), "999")
+    }
+    
+    func testFormatLargeNumberThousands() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        XCTAssertEqual(allCommitsView.formatLargeNumber(1000), "1.0K")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(1500), "1.5K")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(2500), "2.5K")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(15000), "15.0K")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(999999), "1000.0K")
+    }
+    
+    func testFormatLargeNumberMillions() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        XCTAssertEqual(allCommitsView.formatLargeNumber(1000000), "1.0M")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(1500000), "1.5M")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(2500000), "2.5M")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(15000000), "15.0M")
+    }
+    
+    func testFormatLargeNumberEdgeCases() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        XCTAssertEqual(allCommitsView.formatLargeNumber(0), "0")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(1), "1")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(999), "999")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(1001), "1.0K")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(999999), "1000.0K")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(1000001), "1.0M")
+    }
+    
+    // MARK: - Message Sanitization Tests
+    
+    func testSanitizeCommitMessageBasic() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        let cleanMessage = "Simple commit message"
+        XCTAssertEqual(allCommitsView.sanitizeCommitMessage(cleanMessage), cleanMessage)
+    }
+    
+    func testSanitizeCommitMessageWhitespace() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        let messageWithWhitespace = "  Message with whitespace  "
+        XCTAssertEqual(allCommitsView.sanitizeCommitMessage(messageWithWhitespace), "Message with whitespace")
+        
+        let messageWithTabs = "Message\twith\ttabs"
+        XCTAssertEqual(allCommitsView.sanitizeCommitMessage(messageWithTabs), "Message with tabs")
+        
+        let messageWithDoubleSpaces = "Message  with  double  spaces"
+        XCTAssertEqual(allCommitsView.sanitizeCommitMessage(messageWithDoubleSpaces), "Message with double spaces")
+    }
+    
+    func testSanitizeCommitMessageNewlines() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        let messageWithNewlines = "First line\nSecond line\nThird line"
+        XCTAssertEqual(allCommitsView.sanitizeCommitMessage(messageWithNewlines), "First line Second line Third line")
+        
+        let messageWithCarriageReturns = "First line\rSecond line\rThird line"
+        XCTAssertEqual(allCommitsView.sanitizeCommitMessage(messageWithCarriageReturns), "First line Second line Third line")
+        
+        let messageWithMixed = "First line\n\rSecond\tline\n\rThird line"
+        XCTAssertEqual(allCommitsView.sanitizeCommitMessage(messageWithMixed), "First line Second line Third line")
+    }
+    
+    func testSanitizeCommitMessageLength() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        let longMessage = String(repeating: "A", count: 250)
+        let sanitized = allCommitsView.sanitizeCommitMessage(longMessage)
+        XCTAssertEqual(sanitized.count, 200, "Should truncate to 200 characters")
+        XCTAssertTrue(sanitized.allSatisfy { $0 == "A" }, "Should preserve all 'A' characters up to limit")
+    }
+    
+    func testSanitizeCommitMessageComplex() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        let complexMessage = "\t  Major refactoring:\n- Updated all legacy components\n- Added new TypeScript definitions\n\r- Fixed multiple performance issues\n\t\t- Updated documentation  "
+        
+        let expected = "Major refactoring: - Updated all legacy components - Added new TypeScript definitions - Fixed multiple performance issues - Updated documentation"
+        XCTAssertEqual(allCommitsView.sanitizeCommitMessage(complexMessage), expected)
+    }
+    
+    // MARK: - CommitRowView Tests
+    
+    func testCommitRowViewBasic() {
+        let commit = CommitData(
+            repo: "test-repo",
+            message: "Test commit message",
+            time: "2h ago",
+            commits: 1,
+            additions: 50,
+            deletions: 20
+        )
+        
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        let commitRowView = CommitRowView(
+            commit: commit,
+            formatNumber: allCommitsView.formatLargeNumber,
+            sanitizeMessage: allCommitsView.sanitizeCommitMessage
+        )
+        
+        XCTAssertNotNil(commitRowView, "CommitRowView should be instantiable")
+        
+        let body = commitRowView.body
+        XCTAssertNotNil(body, "CommitRowView should have a body")
+    }
+    
+    func testCommitRowViewWithLargeNumbers() {
+        let commit = CommitData(
+            repo: "big-refactor",
+            message: "Major code refactoring",
+            time: "1d ago",
+            commits: 1,
+            additions: 15000,
+            deletions: 8500
+        )
+        
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        let commitRowView = CommitRowView(
+            commit: commit,
+            formatNumber: allCommitsView.formatLargeNumber,
+            sanitizeMessage: allCommitsView.sanitizeCommitMessage
+        )
+        
+        XCTAssertNotNil(commitRowView, "Should handle large numbers")
+        
+        // Test that formatting functions work correctly
+        XCTAssertEqual(allCommitsView.formatLargeNumber(commit.additions!), "15.0K")
+        XCTAssertEqual(allCommitsView.formatLargeNumber(commit.deletions!), "8.5K")
+    }
+    
+    func testCommitRowViewWithNilValues() {
+        let commit = CommitData(
+            repo: "test-repo",
+            message: "Test commit without stats",
+            time: "3h ago",
+            commits: 1,
+            additions: nil,
+            deletions: nil
+        )
+        
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        let commitRowView = CommitRowView(
+            commit: commit,
+            formatNumber: allCommitsView.formatLargeNumber,
+            sanitizeMessage: allCommitsView.sanitizeCommitMessage
+        )
+        
+        XCTAssertNotNil(commitRowView, "Should handle nil additions/deletions")
+    }
+    
+    func testCommitRowViewWithZeroValues() {
+        let commit = CommitData(
+            repo: "test-repo",
+            message: "Commit with zero changes",
+            time: "1h ago",
+            commits: 1,
+            additions: 0,
+            deletions: 0
+        )
+        
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        let commitRowView = CommitRowView(
+            commit: commit,
+            formatNumber: allCommitsView.formatLargeNumber,
+            sanitizeMessage: allCommitsView.sanitizeCommitMessage
+        )
+        
+        XCTAssertNotNil(commitRowView, "Should handle zero values")
+    }
+    
+    func testCommitRowViewWithDirtyMessage() {
+        let commit = CommitData(
+            repo: "test-repo",
+            message: "  Messy commit message\n\nWith newlines\tand tabs  ",
+            time: "4h ago",
+            commits: 1,
+            additions: 100,
+            deletions: 50
+        )
+        
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        let sanitized = allCommitsView.sanitizeCommitMessage(commit.message)
+        
+        XCTAssertEqual(sanitized, "Messy commit message With newlines and tabs")
+        
+        let commitRowView = CommitRowView(
+            commit: commit,
+            formatNumber: allCommitsView.formatLargeNumber,
+            sanitizeMessage: allCommitsView.sanitizeCommitMessage
+        )
+        
+        XCTAssertNotNil(commitRowView, "Should handle dirty commit messages")
+    }
+    
+    // MARK: - View State Tests
+    
+    func testAllCommitsViewWithLoadingState() {
+        dataModel.isLoading = true
+        dataModel.errorMessage = nil
+        dataModel.monthlyCommits = []
+        
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        XCTAssertNotNil(allCommitsView, "Should handle loading state")
+    }
+    
+    func testAllCommitsViewWithErrorState() {
+        dataModel.isLoading = false
+        dataModel.errorMessage = "Failed to fetch commits"
+        dataModel.monthlyCommits = []
+        
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        XCTAssertNotNil(allCommitsView, "Should handle error state")
+    }
+    
+    func testAllCommitsViewWithEmptyState() {
+        dataModel.isLoading = false
+        dataModel.errorMessage = nil
+        dataModel.monthlyCommits = []
+        
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        XCTAssertNotNil(allCommitsView, "Should handle empty state")
+    }
+    
+    func testAllCommitsViewWithContentState() {
+        dataModel.isLoading = false
+        dataModel.errorMessage = nil
+        dataModel.monthlyCommits = [
+            CommitData(repo: "test-repo", message: "Test commit", time: "1h ago", commits: 1, additions: 50, deletions: 20)
+        ]
+        
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        XCTAssertNotNil(allCommitsView, "Should handle content state")
+    }
+    
+    // MARK: - Edge Cases and Performance Tests
+    
+    func testAllCommitsViewWithManyCommits() {
+        // Create a large number of commits to test performance
+        var commits: [CommitData] = []
+        for i in 0..<100 {
+            commits.append(CommitData(
+                repo: "repo-\(i)",
+                message: "Commit number \(i)",
+                time: "\(i)h ago",
+                commits: 1,
+                additions: Int.random(in: 1...1000),
+                deletions: Int.random(in: 1...500)
+            ))
+        }
+        
+        dataModel.isLoading = false
+        dataModel.errorMessage = nil
+        dataModel.monthlyCommits = commits
+        
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        XCTAssertNotNil(allCommitsView, "Should handle many commits efficiently")
+        
+        let countText = allCommitsView.commitCountText
+        XCTAssertEqual(countText, "100 commits", "Should correctly count many commits")
+    }
+    
+    func testFormattingFunctionPerformance() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        // Test formatting performance with many calls
+        measure {
+            for _ in 0..<1000 {
+                _ = allCommitsView.formatLargeNumber(Int.random(in: 1...10000000))
+            }
+        }
+    }
+    
+    func testSanitizationPerformance() {
+        let allCommitsView = AllCommitsView(dataModel: dataModel)
+        
+        let testMessages = [
+            "Simple message",
+            "Message\nwith\nnewlines",
+            "  Message  with  whitespace  ",
+            String(repeating: "Long message ", count: 50),
+            "Complex\n\rmessage\twith\tall\ttypes\nof\rwhitespace"
+        ]
+        
+        // Test sanitization performance
+        measure {
+            for _ in 0..<1000 {
+                for message in testMessages {
+                    _ = allCommitsView.sanitizeCommitMessage(message)
+                }
+            }
+        }
+    }
+}

--- a/GitStreakTests/GitHubServiceFunctionalTests.swift
+++ b/GitStreakTests/GitHubServiceFunctionalTests.swift
@@ -318,7 +318,8 @@ class GitHubServiceFunctionalTests: XCTestCase {
                 message: message,
                 committer: Committer(date: formatter.string(from: date))
             ),
-            repository: Repository(name: repo)
+            repository: Repository(name: repo, owner: nil),
+            stats: nil
         )
     }
     
@@ -337,11 +338,11 @@ class GitHubServiceFunctionalTests: XCTestCase {
         let weekday = calendar.component(.weekday, from: today)
         let daysFromMonday = (weekday == 1) ? 6 : weekday - 2
         guard let startOfWeek = calendar.date(byAdding: .day, value: -daysFromMonday, to: calendar.startOfDay(for: today)) else {
-            return ContributionStats(currentStreak: 0, bestStreak: 0, weeklyCommits: [:], recentCommits: [])
+            return ContributionStats(currentStreak: 0, bestStreak: 0, weeklyCommits: [:], recentCommits: [], monthlyCommits: [])
         }
         
         guard let endOfWeek = calendar.date(byAdding: .day, value: 6, to: startOfWeek) else {
-            return ContributionStats(currentStreak: 0, bestStreak: 0, weeklyCommits: [:], recentCommits: [])
+            return ContributionStats(currentStreak: 0, bestStreak: 0, weeklyCommits: [:], recentCommits: [], monthlyCommits: [])
         }
         
         for commit in commits {
@@ -368,6 +369,16 @@ class GitHubServiceFunctionalTests: XCTestCase {
                     message: commit.commit.message,
                     time: formatRelativeTimeFromStringForTesting(commit.commit.committer.date),
                     commits: 1
+                )
+            },
+            monthlyCommits: commits.prefix(30).map { commit in
+                CommitData(
+                    repo: commit.repository.name,
+                    message: commit.commit.message,
+                    time: formatRelativeTimeFromStringForTesting(commit.commit.committer.date),
+                    commits: 1,
+                    additions: commit.stats?.additions,
+                    deletions: commit.stats?.deletions
                 )
             }
         )

--- a/GitStreakTests/GitStreakDataModelTests.swift
+++ b/GitStreakTests/GitStreakDataModelTests.swift
@@ -445,7 +445,8 @@ class GitStreakDataModelTests: XCTestCase {
                         date: ISO8601DateFormatter().string(from: commitDate)
                     )
                 ),
-                repository: Repository(name: "test-repo")
+                repository: Repository(name: "test-repo", owner: nil),
+                stats: nil
             )
             commits.append(commit)
         }

--- a/GitStreakTests/GitStreakIntegrationTests.swift
+++ b/GitStreakTests/GitStreakIntegrationTests.swift
@@ -223,7 +223,8 @@ class GitStreakIntegrationTests: XCTestCase {
                     message: "Test commit",
                     committer: Committer(date: "invalid-date")
                 ),
-                repository: Repository(name: "test-repo")
+                repository: Repository(name: "test-repo", owner: nil),
+                stats: nil
             ),
             GitHubCommit(
                 sha: "def456",
@@ -231,7 +232,8 @@ class GitStreakIntegrationTests: XCTestCase {
                     message: "Another test commit",
                     committer: Committer(date: "")
                 ),
-                repository: Repository(name: "test-repo")
+                repository: Repository(name: "test-repo", owner: nil),
+                stats: nil
             )
         ]
         
@@ -253,7 +255,8 @@ class GitStreakIntegrationTests: XCTestCase {
                 message: "Invalid commit",
                 committer: Committer(date: "not-a-date")
             ),
-            repository: Repository(name: "test-repo")
+            repository: Repository(name: "test-repo", owner: nil),
+            stats: nil
         )
         
         let mixedCommits = [validCommit, invalidCommit]
@@ -364,7 +367,8 @@ class GitStreakIntegrationTests: XCTestCase {
                 message: message,
                 committer: Committer(date: formatter.string(from: date))
             ),
-            repository: Repository(name: repo)
+            repository: Repository(name: repo, owner: nil),
+            stats: nil
         )
     }
     


### PR DESCRIPTION
## Summary
- Added a new "View All" feature to the Recent Activity section that displays the last 30 days of commit history
- Created `AllCommitsView` with consistent design elements matching the main dashboard
- Enhanced data model to support monthly commit tracking with additions/deletions statistics

## Changes Made

### New Components
- **AllCommitsView.swift**: New SwiftUI view for displaying extended commit history
  - Monthly summary card showing total commits count
  - Detailed commit list with repository names, messages, and timestamps
  - Addition/deletion statistics for each commit
  - Gradient backgrounds and shadows matching the app's design system

### Data Model Updates
- Extended `CommitData` struct to include `additions` and `deletions` properties
- Added `monthlyCommits` property to `GitStreakDataModel`
- Updated `ContributionStats` to fetch and process monthly commit data
- Added mock data with 15+ sample commits for demonstration

### Navigation Integration
- Wired up "View All" button in Recent Activity section
- Implemented sheet presentation for the new view
- Added proper dismiss functionality with "Done" button

## Screenshots
The new View All view displays:
- A header showing "Last 30 Days" with total commit count
- Individual commit cards with:
  - Repository name
  - Commit message
  - Time ago (e.g., "3d ago")
  - Addition/deletion counts with color-coded indicators
  - Consistent styling with green gradient icons

## Test Plan
- [x] Build and run the app successfully
- [x] Tap "View All" button in Recent Activity section
- [x] Verify the AllCommitsView appears with proper styling
- [x] Check that commit data displays correctly with mock data
- [x] Test dismiss functionality with "Done" button
- [x] Verify design consistency with main dashboard
- [ ] Test with real GitHub data when authenticated
- [ ] Verify performance with large commit lists

🤖 Generated with [Claude Code](https://claude.ai/code)