### PR TITLE
Implement pull-to-refresh functionality across all main views

### DIFF
--- a/GitStreak/ContentView.swift
+++ b/GitStreak/ContentView.swift
@@ -124,11 +124,24 @@ struct HomeView: View {
             }
             .padding(.bottom, 20)
         }
+        .refreshable {
+            await refreshData()
+        }
         .sheet(isPresented: $showSettings) {
             SettingsView(dataModel: dataModel)
         }
         .sheet(isPresented: $showAllCommits) {
             AllCommitsView(dataModel: dataModel)
+        }
+    }
+    
+    private func refreshData() async {
+        // Add a small delay to show the refresh indicator
+        try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
+        
+        // Refresh the data
+        await MainActor.run {
+            dataModel.refreshData()
         }
     }
     
@@ -259,8 +272,21 @@ struct StatsView: View {
             .padding(.horizontal, 24)
             .padding(.vertical, 20)
         }
+        .refreshable {
+            await refreshData()
+        }
         .background(Color(.systemGroupedBackground))
         .navigationTitle("Statistics")
+    }
+    
+    private func refreshData() async {
+        // Add a small delay to show the refresh indicator
+        try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
+        
+        // Refresh the data
+        await MainActor.run {
+            dataModel.refreshData()
+        }
     }
 }
 

--- a/GitStreak/Views/AllCommitsView.swift
+++ b/GitStreak/Views/AllCommitsView.swift
@@ -282,6 +282,19 @@ struct AllCommitsView: View {
                 .padding(.bottom, 24)
             }
         }
+        .refreshable {
+            await refreshData()
+        }
+    }
+    
+    private func refreshData() async {
+        // Add a small delay to show the refresh indicator
+        try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
+        
+        // Refresh the data
+        await MainActor.run {
+            dataModel.refreshData()
+        }
     }
 }
 

--- a/GitStreak/Views/AwardsTabView.swift
+++ b/GitStreak/Views/AwardsTabView.swift
@@ -78,8 +78,21 @@ struct AwardsTabView: View {
             .padding(.horizontal, 24)
             .padding(.vertical, 20)
         }
+        .refreshable {
+            await refreshData()
+        }
         .navigationTitle("Awards")
         .background(Color(.systemGroupedBackground))
+    }
+    
+    private func refreshData() async {
+        // Add a small delay to show the refresh indicator
+        try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
+        
+        // Refresh the data
+        await MainActor.run {
+            dataModel.refreshData()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
• Added pull-to-refresh functionality to all major scrollable views in the app
• Users can now refresh data by pulling down on any screen with scrollable content
• Implemented consistent async refresh pattern with visual feedback across all views
• Enhanced user experience with native iOS pull-to-refresh gestures

## Changes Made
- **HomeView**: Added pull-to-refresh to main scroll view for streaks, activity, and achievements
- **StatsView**: Added pull-to-refresh for statistics, insights, and achievement progress
- **AwardsTabView**: Added pull-to-refresh for achievement categories and recent achievements  
- **AllCommitsView**: Added pull-to-refresh for commit history and monthly data

## Technical Implementation
- Uses SwiftUI's native `.refreshable` modifier for consistent iOS behavior
- Implements async refresh pattern with `await refreshData()` function
- Includes 0.5 second delay to provide visual feedback during refresh
- All views call `dataModel.refreshData()` for unified data updates

## User Experience
- **Intuitive Gesture**: Standard iOS pull-to-refresh on all scrollable screens
- **Visual Feedback**: Native refresh indicator with appropriate timing
- **Consistent Behavior**: Same refresh pattern across Home, Awards, Stats, and All Commits views
- **Non-blocking**: Async operations maintain app responsiveness during refresh

## Test plan
- [x] Verify pull-to-refresh works on HomeView
- [x] Verify pull-to-refresh works on StatsView  
- [x] Verify pull-to-refresh works on AwardsTabView
- [x] Verify pull-to-refresh works on AllCommitsView
- [x] Build and run app successfully on iOS Simulator
- [x] Test refresh gesture provides appropriate visual feedback

🤖 Generated with [Claude Code](https://claude.ai/code)