### PR TITLE
Enhance commit tracking and API performance

### DIFF
--- a/GitStreak/ContentView.swift
+++ b/GitStreak/ContentView.swift
@@ -262,7 +262,7 @@ struct StatsView: View {
                             // Invisible spacer card to maintain alignment
                             StatCardView(
                                 title: "Total Commits", 
-                                value: "\(dataModel.recentCommits.count)",
+                                value: "\(dataModel.totalLifetimeCommits)",
                                 color: .orange
                             )
                         }


### PR DESCRIPTION
## Summary
• Added total lifetime commits display using GitHub Search API instead of misleading count (was showing 5)
• Increased API pagination from 30 to 100 commits per repository for more comprehensive data collection  
• Enhanced commit data limits from 150 to 500 total commits across all repositories

## Test plan
- [x] Verify Total Commits tile now shows actual lifetime commits from GitHub
- [x] Confirm All Commits view displays more complete commit history (up to 100 per repo)
- [x] Test both authenticated and non-authenticated user flows
- [x] Ensure GitHub API rate limits are respected with new pagination

🤖 Generated with [Claude Code](https://claude.ai/code)